### PR TITLE
Eerdere cron

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 5 * * *'
+    - cron: '0 1 * * *'
 
 name: Check issues
 jobs:


### PR DESCRIPTION
De workflow draait de laatste dagen pas rond half elf:
https://github.com/Logius-standaarden/Overleg/actions?query=event%3Aschedule

Voorstel de gewenste tijd te vervroegen.